### PR TITLE
Fix version_check URL

### DIFF
--- a/BepInEx/plugins/Leek/swinfo.json
+++ b/BepInEx/plugins/Leek/swinfo.json
@@ -6,7 +6,7 @@
     "description": "Leek",
     "source": "https://github.com/Safarte/Leek",
     "version": "1.0.0",
-    "version_check": "https://raw.githubusercontent.com/Safarte/Leek/main/swinfo.json",
+    "version_check": "https://raw.githubusercontent.com/Safarte/Leek/main/BepInEx/plugins/Leek/swinfo.json",
     "ksp2_version": {
       "min": "0.1.3",
       "max": "*"


### PR DESCRIPTION
Hi @Safarte,

The current version_check URL is a 404 (path within repo is missing). This PR fixes it.

Noticed while working on KSP-CKAN/KSP2-NetKAN#85.

Cheers!
